### PR TITLE
feat: implement dynamic tenant branding and session management across…

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'static.recrutr.in',
+        pathname: '/assets/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(admin)/dashboard/layout.tsx
+++ b/src/app/(admin)/dashboard/layout.tsx
@@ -1,17 +1,65 @@
-import React from 'react';
+'use client';
+
+import React, { useEffect, useState } from 'react';
 import DashboardShell from '@/components/layout/DashboardShell';
+import type { PlatformBranding } from '@/lib/auth/types';
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
 }
 
+interface SessionData {
+  user?: { role: string };
+  expiresAt: string;
+  branding?: PlatformBranding;
+}
+
+/**
+ * Get tenant session data including branding
+ */
+function getTenantSession(): SessionData | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const sessionData = localStorage.getItem('rtr-admin-session');
+    if (!sessionData) return null;
+
+    const session = JSON.parse(sessionData) as SessionData;
+
+    // Check if session has expired
+    const expiresAt = new Date(session.expiresAt);
+    if (expiresAt.getTime() <= Date.now()) {
+      localStorage.removeItem('rtr-admin-session');
+      return null;
+    }
+
+    return session;
+  } catch (error) {
+    console.error('Error getting tenant session:', error);
+    return null;
+  }
+}
+
 export default function DashboardLayout({ children }: DashboardLayoutProps) {
-  // TODO: Replace with actual tenant data from your auth/tenant system
+  const [sessionData, setSessionData] = useState<SessionData | null>(null);
+
+  useEffect(() => {
+    const session = getTenantSession();
+    if (session) {
+      setSessionData(session);
+    }
+  }, []);
+
+  // Use branding from session, fallback to defaults
+  const branding = sessionData?.branding;
+  console.log('Dashboard Layout - Session Data:', sessionData);
+  console.log('Dashboard Layout - Branding:', branding);
   const tenantData = {
-    name: 'Acme Corp',
-    logo: undefined, // TODO: Add tenant logo URL
+    name: branding?.navbar_title || branding?.name || 'Acme Corp',
+    logo: branding?.logo_url,
     environment: process.env.NODE_ENV === 'development' ? 'dev' as const : undefined,
   };
+  console.log('Dashboard Layout - Tenant Data:', tenantData);
 
   return (
     <DashboardShell

--- a/src/app/(admin)/dashboard/layout.tsx
+++ b/src/app/(admin)/dashboard/layout.tsx
@@ -59,7 +59,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     logo: branding?.logo_url,
     environment: process.env.NODE_ENV === 'development' ? 'dev' as const : undefined,
   };
-  console.log('Dashboard Layout - Tenant Data:', tenantData);
 
   return (
     <DashboardShell

--- a/src/app/(admin)/dashboard/layout.tsx
+++ b/src/app/(admin)/dashboard/layout.tsx
@@ -53,7 +53,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   // Use branding from session, fallback to defaults
   const branding = sessionData?.branding;
   console.log('Dashboard Layout - Session Data:', sessionData);
-  console.log('Dashboard Layout - Branding:', branding);
   const tenantData = {
     name: branding?.navbar_title || branding?.name || 'Acme Corp',
     logo: branding?.logo_url,

--- a/src/app/sa/layout.tsx
+++ b/src/app/sa/layout.tsx
@@ -73,7 +73,6 @@ export default function SuperadminLayout({
     environment: process.env.NODE_ENV === 'development' ? 'dev' as const : undefined,
   };
 
-  console.log('Platform Data:', platformData);
 
   return (
     <DashboardShell

--- a/src/app/sa/layout.tsx
+++ b/src/app/sa/layout.tsx
@@ -1,39 +1,46 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import DashboardShell from '@/components/layout/DashboardShell';
+import type { PlatformBranding } from '@/lib/auth/types';
+
+interface SessionData {
+  user?: { role: string };
+  expiresAt: string;
+  branding?: PlatformBranding;
+}
 
 /**
- * Check if user has valid superadmin session
+ * Check if user has valid superadmin session and return session data
  */
-function checkSuperadminAuth(): boolean {
-  if (typeof window === 'undefined') return false;
+function getSuperadminSession(): SessionData | null {
+  if (typeof window === 'undefined') return null;
 
   try {
     // Check for stored session
     const sessionData = localStorage.getItem('rtr-admin-session');
-    if (!sessionData) return false;
+    if (!sessionData) return null;
 
-    const session = JSON.parse(sessionData);
+    const session = JSON.parse(sessionData) as SessionData;
 
     // Check if session has expired
     const expiresAt = new Date(session.expiresAt);
     if (expiresAt.getTime() <= Date.now()) {
       // Session expired, clear it
       localStorage.removeItem('rtr-admin-session');
-      return false;
+      return null;
     }
 
     // Check if user is superadmin
     if (session.user?.role !== 'SUPERADMIN') {
-      return false;
+      return null;
     }
 
-    return true;
+    return session;
   } catch (error) {
     console.error('Error checking superadmin auth:', error);
-    return false;
+    return null;
   }
 }
 
@@ -43,23 +50,30 @@ export default function SuperadminLayout({
   children: React.ReactNode;
 }) {
   const router = useRouter();
+  const [sessionData, setSessionData] = useState<SessionData | null>(null);
 
   useEffect(() => {
-    const isAuthenticated = checkSuperadminAuth();
+    const session = getSuperadminSession();
 
-    if (!isAuthenticated) {
+    if (!session) {
       // Store current path for redirect after login
       sessionStorage.setItem('redirect_after_login', window.location.pathname);
       router.push('/sa/login');
+    } else {
+      setSessionData(session);
     }
   }, [router]);
 
-  // Platform/Superadmin branding
+  // Use branding from session, fallback to defaults
+  const branding = sessionData?.branding;
+  console.log('Branding:', branding);
   const platformData = {
-    name: 'RTR Admin Portal',
-    logo: undefined, // TODO: Add platform logo URL if needed
+    name: branding?.navbar_title || branding?.name || 'RTR Admin Portal',
+    logo: branding?.logo_url,
     environment: process.env.NODE_ENV === 'development' ? 'dev' as const : undefined,
   };
+
+  console.log('Platform Data:', platformData);
 
   return (
     <DashboardShell

--- a/src/app/sa/login/page.tsx
+++ b/src/app/sa/login/page.tsx
@@ -35,15 +35,24 @@ export default function SuperadminLoginPage() {
       // Import auth client dynamically to avoid SSR issues
       const { AuthClient } = await import('@/lib/api/authClient');
       const authClient = new AuthClient();
-      
+
       // Attempt real API login
       const session = await authClient.login({
         email: formData.email,
         password: formData.password,
         audience: 'platform' // Use platform audience for superadmin
       });
-      
-      // Store user info
+
+      // Store session with branding to localStorage
+      const persistedSession = {
+        token: session.token,
+        expiresAt: session.expiresAt.toISOString(),
+        user: session.user,
+        branding: session.branding,
+      };
+      localStorage.setItem('rtr-admin-session', JSON.stringify(persistedSession));
+
+      // Store user info for backward compatibility
       localStorage.setItem('user_role', session.user.role);
       localStorage.setItem('user_email', session.user.email);
       localStorage.setItem('user_name', session.user.name);
@@ -61,8 +70,8 @@ export default function SuperadminLoginPage() {
       }
     } catch (loginError: unknown) {
       console.error('Login failed:', loginError);
-      const errorMessage = loginError instanceof Error 
-        ? loginError.message 
+      const errorMessage = loginError instanceof Error
+        ? loginError.message
         : 'Please check your credentials and ensure the API server is running';
       error('Login failed', errorMessage);
     } finally {

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -153,7 +153,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             user: nextSession.user,
             branding: nextSession.branding,
           };
-          console.log('Storing session with branding to localStorage:', persist.branding);
           window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persist));
         } else {
           window.localStorage.removeItem(STORAGE_KEY);

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -70,6 +70,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           token: parsed.token,
           expiresAt,
           user: parsed.user,
+          branding: parsed.branding,
         };
 
         setSession(normalized);
@@ -150,7 +151,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             token: nextSession.token,
             expiresAt: nextSession.expiresAt.toISOString(),
             user: nextSession.user,
+            branding: nextSession.branding,
           };
+          console.log('Storing session with branding to localStorage:', persist.branding);
           window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persist));
         } else {
           window.localStorage.removeItem(STORAGE_KEY);

--- a/src/components/layout/DashboardShell.tsx
+++ b/src/components/layout/DashboardShell.tsx
@@ -20,12 +20,6 @@ interface DashboardShellProps {
   environment?: 'dev' | 'staging' | 'prod';
 }
 
-const PLATFORM_BRANDING = {
-  name: 'RTR Admin',
-  logo: undefined as string | undefined,
-  environment: process.env.NODE_ENV === 'development' ? 'dev' as const : undefined,
-};
-
 export default function DashboardShell({
   children,
   tenantName = 'Acme Corp',
@@ -77,20 +71,18 @@ export default function DashboardShell({
     [rawNavbarItems]
   );
 
-  const branding = React.useMemo(() => {
-    if (navigationRole === 'superadmin') {
-      return PLATFORM_BRANDING;
-    }
-    return {
-      name: tenantName,
-      logo: tenantLogo,
-      environment,
-    };
-  }, [environment, navigationRole, tenantLogo, tenantName]);
+  // Always use the props passed from the layout (which includes dynamic branding from backend)
+  const branding = React.useMemo(() => ({
+    name: tenantName,
+    logo: tenantLogo,
+    environment,
+  }), [environment, tenantLogo, tenantName]);
 
   const sidebarConfig = React.useMemo(() => {
     if (navigationRole === 'superadmin') {
       return createSuperadminSidebarConfig({
+        tenantName: branding.name,
+        tenantLogo: branding.logo,
         userName: user?.name ?? DEFAULT_VALUES.USER_NAME,
         userEmail: user?.email ?? DEFAULT_VALUES.USER_EMAIL,
         currentPath: pathname,
@@ -112,7 +104,7 @@ export default function DashboardShell({
       },
       userPermissions: permissions,
     });
-  }, [branding.name, branding.logo, logout, navigationRole, pathname, permissions, role, user]);
+  }, [branding, logout, navigationRole, pathname, permissions, role, user]);
 
   if (isLoading) {
     return (

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -108,6 +108,8 @@ export default function Navbar({
                 <Image
                   src={tenantLogo}
                   alt={`${tenantName} logo`}
+                  width={32}
+                  height={32}
                   className="h-8 w-8 rounded-md object-cover"
                 />
               ) : (
@@ -233,6 +235,8 @@ export default function Navbar({
                 <Image
                   src={tenantLogo}
                   alt={`${tenantName} logo`}
+                  width={32}
+                  height={32}
                   className="h-8 w-8 rounded-md object-cover"
                 />
               ) : (

--- a/src/components/ui/Sidebar/Sidebar.tsx
+++ b/src/components/ui/Sidebar/Sidebar.tsx
@@ -185,6 +185,8 @@ export default function Sidebar({
                         <Image
                           src={header.logo.src}
                           alt={header.logo.alt || 'Logo'}
+                          width={32}
+                          height={32}
                           className="h-8 w-8 rounded-md object-cover"
                         />
                       )}
@@ -323,13 +325,10 @@ export default function Sidebar({
                       <Image
                         src={footer.user.avatar}
                         alt={footer.user.name}
+                        width={32}
+                        height={32}
                         className='w-8 h-8 rounded-full object-cover'
-                        />
-                      // <img
-                      //   src={footer.user.avatar}
-                      //   alt={footer.user.name}
-                      //   className="w-8 h-8 rounded-full object-cover"
-                      // />
+                      />
                     ) : (
                       <span className="text-sm font-medium text-blue-600">
                         {footer.user.name.charAt(0).toUpperCase()}

--- a/src/config/dashboardSidebar.ts
+++ b/src/config/dashboardSidebar.ts
@@ -148,6 +148,8 @@ export function createDashboardSidebarConfig(config: {
 }
 
 export function createSuperadminSidebarConfig(config: {
+  tenantName?: string;
+  tenantLogo?: string;
   userName: string;
   userEmail: string;
   currentPath: string;
@@ -174,9 +176,14 @@ export function createSuperadminSidebarConfig(config: {
     sections: markActiveSections(sections, config.currentPath),
 
     header: {
-      title: 'RTR Admin Portal',
+      title: config.tenantName || 'RTR Admin Portal',
       subtitle: 'Super Admin',
-      logo: undefined, // TODO: Add platform logo if needed
+      logo: config.tenantLogo
+        ? {
+            src: config.tenantLogo,
+            alt: `${config.tenantName} logo`,
+          }
+        : undefined,
     },
 
     footer: {
@@ -242,10 +249,3 @@ export function createSimpleSidebarConfig(currentPath: string): SidebarProps {
     width: 'w-48',
   };
 }
-
-
-
-
-
-
-

--- a/src/lib/api/authClient.ts
+++ b/src/lib/api/authClient.ts
@@ -7,6 +7,7 @@ import type {
   LoginCredentials,
   LoginAudience,
   Permission,
+  PlatformBranding,
 } from '@/lib/auth/types';
 import { rolePermissions } from '@/lib/auth/permissions';
 
@@ -19,10 +20,21 @@ const apiUserSchema = z.object({
   MustChangePassword: z.boolean().default(false),
 });
 
+const platformBrandingSchema = z.object({
+  name: z.string(),
+  logo_url: z.string().optional(),
+  primary_color: z.string().optional(),
+  accent_color: z.string().optional(),
+  navbar_title: z.string().optional(),
+  sidebar_title: z.string().optional(),
+  // Ignoring sidebar_links as frontend has its own navigation structure
+}).optional();
+
 const loginResponseSchema = z.object({
   Token: z.string(),
   ExpiresAt: z.string(),
   User: apiUserSchema,
+  PlatformBranding: platformBrandingSchema,
 });
 
 type LoginApiResponse = z.infer<typeof loginResponseSchema>;
@@ -43,6 +55,7 @@ function mapSession(payload: LoginApiResponse): AuthSession {
     token: payload.Token,
     expiresAt: new Date(payload.ExpiresAt),
     user: mapUser(payload.User),
+    branding: payload.PlatformBranding,
   };
 }
 
@@ -70,6 +83,7 @@ export class AuthClient {
     );
 
     console.log('Login successful, processing response');
+    console.log('PlatformBranding from backend:', response.PlatformBranding);
 
     // Store the token for future API calls
     if (typeof window !== 'undefined') {
@@ -77,7 +91,9 @@ export class AuthClient {
       localStorage.setItem('authToken', response.Token); // Backup key
     }
 
-    return mapSession(response);
+    const session = mapSession(response);
+    console.log('Mapped session with branding:', session.branding);
+    return session;
   }
 
   async logout(options: { audience: LoginAudience; tenantId?: string }): Promise<void> {

--- a/src/lib/api/authClient.ts
+++ b/src/lib/api/authClient.ts
@@ -83,7 +83,6 @@ export class AuthClient {
     );
 
     console.log('Login successful, processing response');
-    console.log('PlatformBranding from backend:', response.PlatformBranding);
 
     // Store the token for future API calls
     if (typeof window !== 'undefined') {

--- a/src/lib/api/authClient.ts
+++ b/src/lib/api/authClient.ts
@@ -91,7 +91,7 @@ export class AuthClient {
     }
 
     const session = mapSession(response);
-    console.log('Mapped session with branding:', session.branding);
+    
     return session;
   }
 

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -9,14 +9,25 @@ export interface AuthUser {
   mustChangePassword: boolean;
 }
 
+export interface PlatformBranding {
+  name: string;
+  logo_url?: string;
+  primary_color?: string;
+  accent_color?: string;
+  navbar_title?: string;
+  sidebar_title?: string;
+}
+
 export interface AuthSession {
   token: string;
   expiresAt: Date;
   user: AuthUser;
+  branding?: PlatformBranding;
 }
 
 export interface StoredAuthSession extends Omit<AuthSession, 'expiresAt'> {
   expiresAt: string;
+  branding?: PlatformBranding;
 }
 
 export type LoginAudience = 'tenant' | 'platform';


### PR DESCRIPTION
This pull request introduces dynamic platform/tenant branding throughout the admin dashboard by retrieving branding information from the backend and persisting it in the session. This enables the display of custom names, logos, and other branding elements for both tenant and superadmin dashboards. The changes also ensure that branding is passed correctly through layouts and sidebar configurations, and that images are rendered with explicit sizes for better performance and consistency.

**Branding and session management improvements:**

* Added `PlatformBranding` support to session types and ensured branding is stored and retrieved from localStorage across authentication flows (`src/lib/auth/types.ts`, `src/components/auth/AuthProvider.tsx`, `src/app/sa/login/page.tsx`, `src/app/(admin)/dashboard/layout.tsx`, `src/app/sa/layout.tsx`). [[1]](diffhunk://#diff-be594eec6d22fc98c5826a4792ca05b7b48652f6357af17d12943bb5515d9056R12-R30) [[2]](diffhunk://#diff-b6d7ac0d737794978ee5b185ac20272e2d0257a28ca8b08b06e377905a034f12R73) [[3]](diffhunk://#diff-b6d7ac0d737794978ee5b185ac20272e2d0257a28ca8b08b06e377905a034f12R154-R156) [[4]](diffhunk://#diff-66e733d66bb3c69e5fb09b64e0a52fc7fd3e62a303deda60bc63a07608aa5a38L46-R55) [[5]](diffhunk://#diff-51b7a1cc78eeafc3f4e5cc57886a16a34a982fcb8a58f271eb7c40806f1ccaa4L1-R62) [[6]](diffhunk://#diff-680dc1f6e494fd9ac68ccb5467562f9f6eedaead11aa26a78426be939de1e118L3-R43) [[7]](diffhunk://#diff-680dc1f6e494fd9ac68ccb5467562f9f6eedaead11aa26a78426be939de1e118R53-R77)
* Updated the `AuthClient` to parse and map backend branding information into the session, and log branding data for debugging (`src/lib/api/authClient.ts`). [[1]](diffhunk://#diff-4f19ca76beda04b4a61fb2935142c9440f94cba1a0db391058e7287be13f46edR10) [[2]](diffhunk://#diff-4f19ca76beda04b4a61fb2935142c9440f94cba1a0db391058e7287be13f46edR23-R37) [[3]](diffhunk://#diff-4f19ca76beda04b4a61fb2935142c9440f94cba1a0db391058e7287be13f46edR58) [[4]](diffhunk://#diff-4f19ca76beda04b4a61fb2935142c9440f94cba1a0db391058e7287be13f46edR86-R96)

**Layout and dashboard shell enhancements:**

* Modified dashboard and superadmin layouts to extract branding from session and pass it to `DashboardShell`, replacing hardcoded branding with dynamic values (`src/app/(admin)/dashboard/layout.tsx`, `src/app/sa/layout.tsx`). [[1]](diffhunk://#diff-51b7a1cc78eeafc3f4e5cc57886a16a34a982fcb8a58f271eb7c40806f1ccaa4L1-R62) [[2]](diffhunk://#diff-680dc1f6e494fd9ac68ccb5467562f9f6eedaead11aa26a78426be939de1e118L3-R43) [[3]](diffhunk://#diff-680dc1f6e494fd9ac68ccb5467562f9f6eedaead11aa26a78426be939de1e118R53-R77)
* Refactored `DashboardShell` to always use branding props from layouts and removed the static `PLATFORM_BRANDING` fallback (`src/components/layout/DashboardShell.tsx`). [[1]](diffhunk://#diff-ac0c00e8aaecc9e160eb893fa07229113493e29d4c06627d0e99973de4daa711L23-L28) [[2]](diffhunk://#diff-ac0c00e8aaecc9e160eb893fa07229113493e29d4c06627d0e99973de4daa711L80-R85) [[3]](diffhunk://#diff-ac0c00e8aaecc9e160eb893fa07229113493e29d4c06627d0e99973de4daa711L115-R107)

**Sidebar and navigation configuration:**

* Updated sidebar config to accept and use tenant/platform branding for header logo and title, allowing for dynamic sidebar branding (`src/config/dashboardSidebar.ts`). [[1]](diffhunk://#diff-1aac3c0bf05e7a95001688f0c99ba010c4329bdaf3c0f98eede8fc132e4e788fR151-R152) [[2]](diffhunk://#diff-1aac3c0bf05e7a95001688f0c99ba010c4329bdaf3c0f98eede8fc132e4e788fL177-R186) [[3]](diffhunk://#diff-1aac3c0bf05e7a95001688f0c99ba010c4329bdaf3c0f98eede8fc132e4e788fL245-L251)

**Image rendering improvements:**

* Added explicit `width` and `height` to all `Image` components rendering logos and avatars for navbar and sidebar, improving layout stability (`src/components/layout/Navbar.tsx`, `src/components/ui/Sidebar/Sidebar.tsx`). [[1]](diffhunk://#diff-3d2e5241bf2cfaf8ba89a0d1290fd3e96f80a98d17172d58ce91f54c6501c302R111-R112) [[2]](diffhunk://#diff-3d2e5241bf2cfaf8ba89a0d1290fd3e96f80a98d17172d58ce91f54c6501c302R238-R239) [[3]](diffhunk://#diff-3b1dc7970a7b2e1fb30dc7d52dc55ace87da18dccb50ce4bb031e27e54e6a5b8R188-R189) [[4]](diffhunk://#diff-3b1dc7970a7b2e1fb30dc7d52dc55ace87da18dccb50ce4bb031e27e54e6a5b8R328-L332)

**Next.js configuration:**

* Allowed remote images from the `static.recrutr.in` domain to support dynamic branding assets (`next.config.ts`).